### PR TITLE
Adding condition to Request constructor to allow processing of json requests.

### DIFF
--- a/mongoose/Request.cpp
+++ b/mongoose/Request.cpp
@@ -17,7 +17,7 @@ namespace Mongoose
 
         // Downloading POST data
         ostringstream postData;
-        if ((isFormURLEncodedContentType(connection) || isJsonContentType(connection)) ) {
+        if (mg_get_header(connection, "Content-Type") != NULL) {
             int n;
             char post[1024];
             while (n = mg_read(connection, post, sizeof(post))) {
@@ -107,20 +107,6 @@ namespace Mongoose
         delete[] buffer;
 
         return true;
-    }
-
-
-    bool Request::isFormURLEncodedContentType(mg_connection *connection)
-    {
-        const char * content_type = mg_get_header(connection, "Content-Type");
-        return (content_type != NULL && strcmp(content_type, "application/x-www-form-urlencoded") == 0);
-    }
-
-
-    bool Request::isJsonContentType(mg_connection *connection)
-    {
-        const char * content_type = mg_get_header(connection, "Content-Type");
-        return (content_type != NULL && strcmp(content_type, "application/json") == 0);
     }
 
 

--- a/mongoose/Request.h
+++ b/mongoose/Request.h
@@ -101,16 +101,6 @@ namespace Mongoose
 #endif
             struct mg_connection *connection;
             const struct mg_request_info *request;
-
-            /**
-             * Determine if the incoming request content type is form URL encoded.
-             */
-            bool isFormURLEncodedContentType(mg_connection *connection);
-
-            /**
-             * Determine if the incoming request content type is JSON.
-             */
-            bool isJsonContentType(mg_connection *connection);
     };
 };
 


### PR DESCRIPTION
Both URL encoded and JSON Content-Type requests are now processed. The raw request body is exposed by a new accessor `Request.getData()`.  Request handlers may use this function along with JsonCpp to easily manage JSON request bodies.
