### PR TITLE
Remove use of macros

### DIFF
--- a/mongoose/Controller.h
+++ b/mongoose/Controller.h
@@ -11,12 +11,6 @@
 
 using namespace std;
 
-#define addRoute(httpMethod, url, controllerType, method) \
-    registerRoute(httpMethod, url, new RequestHandler<controllerType, StreamResponse>(this, &controllerType::method ));
-
-#define addRouteResponse(httpMethod, url, controllerType, method, responseType) \
-    registerRoute(httpMethod, url, new RequestHandler<controllerType, responseType>(this, &controllerType::method ));
-
 /**
  * A controller is a module that respond to requests
  *
@@ -145,6 +139,16 @@ namespace Mongoose
 
             virtual bool handles(string method, string url);
             vector<string> getUrls();
+
+            template<typename C>
+            void addRoute(const std::string& httpMethod, const std::string& url, void (C::*func)(Request&, StreamResponse&)){
+                registerRoute(httpMethod, url, new RequestHandler<C, StreamResponse>(static_cast<C*>(this), func));
+            }
+
+            template<typename C, typename R>
+            void addRouteResponse(const std::string& httpMethod, const std::string& url, void (C::*func)(Request&, R&)){
+                registerRoute(httpMethod, url, new RequestHandler<C, R>(static_cast<C*>(this), func));
+            }
 
         protected:
             Sessions *sessions;


### PR DESCRIPTION
This pull request removes the only two macros used in this project. This has the advantages of:
1) Not using macros anymore
2) Not forcing the user to use "using namespace Mongoose" which is a very bad code smell in my opinion

Since this break the compatibility, if you don't want it, could you at least qualify all the names used inside the macro with Mongoose:: ? So that the user is not forced to use complete namespaces...
