### PR TITLE
No "using namespace" in headers

### DIFF
--- a/mongoose/Controller.h
+++ b/mongoose/Controller.h
@@ -9,8 +9,6 @@
 #include "WebSocket.h"
 #include "Sessions.h"
 
-using namespace std;
-
 #define addRoute(httpMethod, url, controllerType, method) \
     registerRoute(httpMethod, url, new RequestHandler<controllerType, StreamResponse>(this, &controllerType::method ));
 
@@ -82,7 +80,7 @@ namespace Mongoose
              *
              * @param string the prefix of all urls for this controller
              */
-            void setPrefix(string prefix);
+            void setPrefix(std::string prefix);
 
             /**
              * Called when a new websocket connection is ready
@@ -97,7 +95,7 @@ namespace Mongoose
              * @param WebSocket the instance of the connection
              * @param string the data arriving
              */
-            virtual void webSocketData(WebSocket *websocket, string data);
+            virtual void webSocketData(WebSocket *websocket, std::string data);
 
             /**
              * Registers a route to the controller
@@ -105,7 +103,7 @@ namespace Mongoose
              * @param string the route path
              * @param RequestHandlerBase the request handler for this route
              */
-            virtual void registerRoute(string httpMethod, string route, RequestHandlerBase *handler);
+            virtual void registerRoute(std::string httpMethod, std::string route, RequestHandlerBase *handler);
 
             /**
              * Initializes the route and settings
@@ -124,7 +122,7 @@ namespace Mongoose
              *
              * @return response a response to send, 404 will occur if NULL
              */
-            virtual Response *serverInternalError(string message);
+            virtual Response *serverInternalError(std::string message);
 
             /**
              * Gets the session for a request/response
@@ -143,15 +141,15 @@ namespace Mongoose
              */
             void setSessions(Sessions *sessions);
 
-            virtual bool handles(string method, string url);
-            vector<string> getUrls();
+            virtual bool handles(std::string method, std::string url);
+            std::vector<std::string> getUrls();
 
         protected:
             Sessions *sessions;
             Server *server;
-            string prefix;
-            map<string, RequestHandlerBase*> routes;
-            vector<string> urls;
+            std::string prefix;
+            std::map<std::string, RequestHandlerBase*> routes;
+            std::vector<std::string> urls;
     };
 }
 

--- a/mongoose/JsonController.h
+++ b/mongoose/JsonController.h
@@ -6,8 +6,6 @@
 #include "WebController.h"
 #include "JsonResponse.h"
 
-using namespace std;
-
 /**
  * A json controller is a controller that serves JSON API
  */

--- a/mongoose/JsonResponse.h
+++ b/mongoose/JsonResponse.h
@@ -8,8 +8,6 @@
 
 #include "Response.h"
 
-using namespace std;
-
 /**
  * A stream response to a request
  */
@@ -25,7 +23,7 @@ namespace Mongoose
              *
              * @return string the response body
              */
-            virtual string getBody();
+            virtual std::string getBody();
 
             /**
              * Sets the human readability of the response

--- a/mongoose/Request.h
+++ b/mongoose/Request.h
@@ -11,8 +11,6 @@
 #include "UploadFile.h"
 #include "Response.h"
 
-using namespace std;
-
 /**
  * Request is a wrapper for the clients requests
  */
@@ -37,7 +35,7 @@ namespace Mongoose
              *
              * @return bool true if the param is present, false else
              */
-            bool hasVariable(string key);
+            bool hasVariable(std::string key);
 
             /**
              * Get All variable present in GET or POST data
@@ -45,7 +43,7 @@ namespace Mongoose
              * @brief getAllVariable
              * @return map<string, string> with all variables
              */
-            map<string, string> getAllVariable();
+            std::map<std::string, std::string> getAllVariable();
 
             /**
              * Get the value for a certain variable
@@ -55,7 +53,7 @@ namespace Mongoose
              *
              * @return string the value of the variable if it exists, fallback else
              */
-            string get(string key, string fallback = "");
+            std::string get(std::string key, std::string fallback = "");
 
             /**
              * Checks if the given cookie exists
@@ -64,7 +62,7 @@ namespace Mongoose
              *
              * @return bool true if the given cookie is set
              */
-            bool hasCookie(string key);
+            bool hasCookie(std::string key);
 
             /**
              * Try to get the cookie value
@@ -74,10 +72,10 @@ namespace Mongoose
              *
              * @retun the value of the cookie if it exists, fallback else
              */
-            string getCookie(string key, string fallback = "");
+            std::string getCookie(std::string key, std::string fallback = "");
 
 
-            string getHeaderKeyValue(const std::string& header_key);
+            std::string getHeaderKeyValue(const std::string& header_key);
 
             /**
              * Handle uploads to the target directory
@@ -87,25 +85,25 @@ namespace Mongoose
              */
             void handleUploads();
 
-            string getUrl();
-            string getMethod();
-            string getData();
+            std::string getUrl();
+            std::string getMethod();
+            std::string getData();
 
 #ifdef ENABLE_REGEX_URL
             smatch getMatches();
-            bool match(string pattern);
+            bool match(std::string pattern);
 #endif
-            bool readVariable(const char *data, string key, string &output);
+            bool readVariable(const char *data, std::string key, std::string &output);
 
             /**
              * Files uploaded in this request
              */
-            vector<UploadFile> uploadFiles;
+            std::vector<UploadFile> uploadFiles;
 
         protected:
-            string method;
-            string url;
-            string data;
+            std::string method;
+            std::string url;
+            std::string data;
             struct mg_connection *connection;
     };
 }

--- a/mongoose/RequestHandler.h
+++ b/mongoose/RequestHandler.h
@@ -31,7 +31,7 @@ namespace Mongoose
                 try {
                     controller->preProcess(request, *response);
                     (controller->*function)(request, *response);
-                } catch (string exception) {
+                } catch (std::string exception) {
                     return controller->serverInternalError(exception);
                 } catch (...) {
                     return controller->serverInternalError("Unknown error");

--- a/mongoose/Response.h
+++ b/mongoose/Response.h
@@ -10,14 +10,12 @@
 #define HTTP_FORBIDDEN 403
 #define HTTP_SERVER_ERROR 500
 
-using namespace std;
-
 /**
  * A response to a request
  */
 namespace Mongoose
 {
-    class Response 
+    class Response
     {
         public:
             Response();
@@ -30,7 +28,7 @@ namespace Mongoose
              *
              * @return bool true if the header is set
              */
-            virtual bool hasHeader(string key);
+            virtual bool hasHeader(std::string key);
 
             /**
              * Sets the header
@@ -39,7 +37,7 @@ namespace Mongoose
              *
              * @param value the header value
              */
-            virtual void setHeader(string key, string value);
+            virtual void setHeader(std::string key, std::string value);
 
             /**
              * Get the data of the response, this will contain headers and
@@ -47,14 +45,14 @@ namespace Mongoose
              *
              * @return string the response data
              */
-            virtual string getData();
+            virtual std::string getData();
 
             /**
              * Gets the response body
              *
              * @return string the response body
              */
-            virtual string getBody()=0;
+            virtual std::string getBody()=0;
 
             /**
              * Sets the cookie, note that you can only define one cookie by request
@@ -63,7 +61,7 @@ namespace Mongoose
              * @param string the key of the cookie
              * @param string value the cookie value
              */
-            virtual void setCookie(string key, string value);
+            virtual void setCookie(std::string key, std::string value);
 
             /**
              * Sets the response code
@@ -72,7 +70,7 @@ namespace Mongoose
 
         protected:
             int code;
-            map<string, string> headers;
+            std::map<std::string, std::string> headers;
     };
 }
 

--- a/mongoose/Server.h
+++ b/mongoose/Server.h
@@ -14,8 +14,6 @@
 #include "Mutex.h"
 #include "Sessions.h"
 
-using namespace std;
-
 /**
  * Wrapper for the Mongoose server
  */
@@ -82,7 +80,7 @@ namespace Mongoose
              *
              * @return int if we have to keep the connection opened
              */
-            int _webSocketData(struct mg_connection *conn, string data);
+            int _webSocketData(struct mg_connection *conn, std::string data);
 
             /**
              * Process the request by controllers
@@ -100,7 +98,7 @@ namespace Mongoose
              * @param string the name of the option
              * @param string the value of the option
              */
-            void setOption(string key, string value);
+            void setOption(std::string key, std::string value);
 
 #ifndef NO_WEBSOCKET
             /**
@@ -124,22 +122,22 @@ namespace Mongoose
             /**
              * Does the server handles url?
              */
-            bool handles(string method, string url);
+            bool handles(std::string method, std::string url);
 
         protected:
             volatile bool stopped;
             volatile bool destroyed;
             Sessions sessions;
             Mutex mutex;
-            map<string, string> optionsMap;
-            map<struct mg_connection*, Request *> currentRequests;
+            std::map<std::string, std::string> optionsMap;
+            std::map<struct mg_connection*, Request *> currentRequests;
             struct mg_server *server;
 
 #ifndef NO_WEBSOCKET
             WebSockets websockets;
 #endif
 
-            vector<Controller *> controllers;
+            std::vector<Controller *> controllers;
 
             // Statistics
             int requests;

--- a/mongoose/Session.h
+++ b/mongoose/Session.h
@@ -4,11 +4,9 @@
 #include <map>
 #include "Mutex.h"
 
-using namespace std;
-
 /**
  * A session contains the user specific values
- */ 
+ */
 namespace Mongoose
 {
     class Session
@@ -22,21 +20,21 @@ namespace Mongoose
              * @param string the name of the variable
              * @param string the value of the variable
              */
-            void setValue(string key, string value);
+            void setValue(std::string key, std::string value);
 
             /**
              * Unset a session varaible
              *
              * @param string the variable name
              */
-            void unsetValue(string key);
+            void unsetValue(std::string key);
 
             /**
              * Check if the given variable exists
              *
              * @param string the name of the variable
              */
-            bool hasValue(string key);
+            bool hasValue(std::string key);
 
             /**
              * Try to get the value for the given variable
@@ -46,7 +44,7 @@ namespace Mongoose
              *
              * @return string the value of the variable if it exists, fallback else
              */
-            string get(string key, string fallback = "");
+            std::string get(std::string key, std::string fallback = "");
 
             /**
              * Pings the session, this will update the creation date to now
@@ -62,7 +60,7 @@ namespace Mongoose
             int getAge();
 
         protected:
-            map<string, string> values;
+            std::map<std::string, std::string> values;
             int date;
             Mutex mutex;
     };

--- a/mongoose/Sessions.h
+++ b/mongoose/Sessions.h
@@ -5,18 +5,16 @@
 #include "Session.h"
 #include "Mutex.h"
 
-using namespace std;
-
 /**
  * A session contains the user specific values
- */ 
+ */
 namespace Mongoose
 {
     class Sessions
     {
         public:
-            Sessions(string key = "sessid");
-			virtual ~Sessions();
+            Sessions(std::string key = "sessid");
+            virtual ~Sessions();
 
             /**
              * Gets the session ID of a certain request,
@@ -28,7 +26,7 @@ namespace Mongoose
              *
              * @return string the session ID for this request
              */
-            string getId(Request &request, Response &response);
+            std::string getId(Request &request, Response &response);
 
             /**
              * Gets the session for a certain request
@@ -48,8 +46,8 @@ namespace Mongoose
             void garbageCollect(int oldAge = 3600);
 
         protected:
-            map<string, Session*> sessions;
-            string key;
+            std::map<std::string, Session*> sessions;
+            std::string key;
             Mutex mutex;
     };
 }

--- a/mongoose/StreamResponse.h
+++ b/mongoose/StreamResponse.h
@@ -7,14 +7,12 @@
 
 #include "Response.h"
 
-using namespace std;
-
 /**
  * A stream response to a request
  */
 namespace Mongoose
 {
-    class StreamResponse : public ostringstream, public Response
+    class StreamResponse : public std::ostringstream, public Response
     {
         public:
             /**
@@ -22,7 +20,7 @@ namespace Mongoose
              *
              * @return string the response body
              */
-            virtual string getBody();
+            virtual std::string getBody();
     };
 }
 

--- a/mongoose/UploadFile.h
+++ b/mongoose/UploadFile.h
@@ -2,8 +2,6 @@
 #define _MONGOOSE_UPLOAD_FILE_H
 #include <string>
 
-using namespace std;
-
 /**
  * A file uploaded in a request
  */
@@ -12,16 +10,16 @@ namespace Mongoose
     class UploadFile
     {
         public:
-            UploadFile(string filename, string data);
+            UploadFile(std::string filename, std::string data);
 
-            string getName();
-            string getData();
+            std::string getName();
+            std::string getData();
 
-            void saveTo(string directory);
+            void saveTo(std::string directory);
 
         protected:
-            string filename;
-            string data;
+            std::string filename;
+            std::string data;
     };
 }
 

--- a/mongoose/Utils.h
+++ b/mongoose/Utils.h
@@ -1,16 +1,12 @@
 #ifndef _MONGOOSE_UTILS_H
 #define _MONGOOSE_UTILS_H
 
-#include <iostream>
-
-using namespace std;
-
 namespace Mongoose
 {
     class Utils
     {
         public:
-            static string htmlEntities(string data);
+            static std::string htmlEntities(std::string data);
             static void sleep(int ms);
     };
 }

--- a/mongoose/WebController.h
+++ b/mongoose/WebController.h
@@ -8,8 +8,6 @@
 #include "StreamResponse.h"
 #include "Utils.h"
 
-using namespace std;
-
 /**
  * A web controller is a controller that serves HTML pages
  */

--- a/mongoose/WebSocket.h
+++ b/mongoose/WebSocket.h
@@ -7,8 +7,6 @@
 #include "Request.h"
 #include "Mutex.h"
 
-using namespace std;
-
 #define WEBSOCKET_FIN 0x80
 
 enum {
@@ -34,7 +32,7 @@ namespace Mongoose
              *
              * @param string the data to send
              */
-            void send(string data, int opcode = WEBSOCKET_OPCODE_TEXT);
+            void send(std::string data, int opcode = WEBSOCKET_OPCODE_TEXT);
 
             /**
              * Returns the connection request
@@ -60,14 +58,14 @@ namespace Mongoose
              *
              * @param string data
              */
-            void appendData(string data);
+            void appendData(std::string data);
 
             /**
              * Gets the internal receive buffer and clear it
              *
              * @return string data
              */
-            string flushData();
+            std::string flushData();
 
             /**
              * Gets the internal mg connection
@@ -110,12 +108,12 @@ namespace Mongoose
         protected:
             int id;
             Mutex mutex;
-            string data;
+            std::string data;
             Request request;
             struct mg_connection *connection;
             bool closed;
 
-            vector<WebSockets *> containers;
+            std::vector<WebSockets *> containers;
     };
 }
 

--- a/mongoose/WebSockets.h
+++ b/mongoose/WebSockets.h
@@ -7,8 +7,6 @@
 #include "WebSocket.h"
 #include "Mutex.h"
 
-using namespace std;
-
 /**
  * WebSockets is an array that contains WebSocket connections, this
  * can be used for instance to broadcast informations to them.
@@ -39,7 +37,7 @@ namespace Mongoose
             /**
              * Send data to all sockets in this container
              */
-            void sendAll(string data);
+            void sendAll(std::string data);
 
             /**
              * Gets the websocket corresponding to the given connection
@@ -60,9 +58,9 @@ namespace Mongoose
              * @param WebSocket* the websocket object
              */
             void remove(WebSocket *websocket, bool lock = true);
-    
+
             /**
-             * Gets the websockets having the id 
+             * Gets the websockets having the id
              *
              * @param int id
              */
@@ -70,8 +68,8 @@ namespace Mongoose
 
         protected:
             Mutex mutex;
-            map<struct mg_connection*, WebSocket*> websockets;
-            map<int, WebSocket*> websocketsById;
+            std::map<struct mg_connection*, WebSocket*> websockets;
+            std::map<int, WebSocket*> websocketsById;
             bool responsible;
 
             int id;


### PR DESCRIPTION
This patch removes all "using namespace" from the headers. This is generally considered a bad practice. 
